### PR TITLE
haloapi.js

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -158,6 +158,7 @@ var cnames_active = {
     ,"gyre": "wridder.github.io/GyreJS"
     ,"h": "makenowjust.github.io/h.js"
     ,"halil" : "hibrahimsafak.github.io"
+    ,"haloapi": "derflatulator.github.io/haloapi.js"
     ,"happy": "e24.github.io/happy"
     ,"hask": "janbiasi.github.io/hask"
     ,"hello": "hello-js-org.github.io"


### PR DESCRIPTION
Link to upstream PR: https://github.com/js-org/dns.js.org/pull/568 

Site: https://derflatulator.github.io/haloapi.js/ 
